### PR TITLE
Fix: Issue#13284 Clear selection doesn't appear in Command Palette continuing on PR #13319

### DIFF
--- a/src/Files.App/Actions/Content/Selection/ClearSelectionAction.cs
+++ b/src/Files.App/Actions/Content/Selection/ClearSelectionAction.cs
@@ -20,13 +20,17 @@ namespace Files.App.Actions
 		{
 			get
 			{
+				var page = context.ShellPage;
+				bool isCommandPaletteOpen = page.ToolbarViewModel.IsCommandPaletteOpen;
+				if (isCommandPaletteOpen)
+					return true;
 				if (context.PageType is ContentPageTypes.Home)
 					return false;
 
 				if (!context.HasSelection)
 					return false;
 
-				var page = context.ShellPage;
+				
 				if (page is null)
 					return false;
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue13284

**Validation**
How did you test these changes?
- [ x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Enter a folder
   3. Open command palette ctrl+shift+p
   4. Select all items
   5. Clear items
   

**Screenshots (optional)**
Add screenshots here.
![image](https://github.com/files-community/Files/assets/117103373/5843b9ae-9854-495c-ab25-7be8e993481b)
